### PR TITLE
docs(*): update markdown files and fix typos - I257

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Accord Project source code files are made available under the [Apache License, V
 
 Accord Project documentation files are made available under the [Creative Commons Attribution 4.0 International License][creativecommons] (CC-BY-4.0).
 
-[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[coc]: https://lfprojects.org/policies/code-of-conduct/
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 
 [contribute.coc]: CONTRIBUTING.md#coc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Cicero VSCode Extension
 
-> Thanks to the angularJS team for the bulk of this text!
+> Thanks to the AngularJS team for the bulk of this text!
 
 We'd love for you to contribute to our source code and to make Cicero VSCode Extension even better than it is today! Here are the guidelines we'd like you to follow:
 
@@ -37,13 +37,13 @@ Other channels for support are:
 
 ### <a name="issue"></a> Found an Issue or Bug?
 
-If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github-issues]. Even better, you can submit a Pull Request with a fix.
+If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
 
-**Please see the **[**Submission Guidelines**][contribute.submit]** below.**
+**Please see the [Submission Guidelines][contribute.submit] below.**
 
 ### <a name="feature"></a> Missing a Feature?
 
-You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+You can request a new feature by [submitting an issue][github-issues] to our GitHub Repository.
 
 If you would like to implement a new feature then consider what kind of change it is:
 
@@ -55,7 +55,7 @@ If you would like to implement a new feature then consider what kind of change i
 
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr], and
 
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -58,7 +58,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 We have very precise rules over how our git commit messages can be formatted.  This leads to **more
 readable messages** that are easy to follow when looking through the **project history** and **git logs**.  
-But also, we use the git commit messages to **generate the Concerto-UI change log**.
+But also, we use the git commit messages to **generate the Cicero VSCode Extension change log**.
 
 The commit message formatting can be added using a version of typical git workflow.
 
@@ -105,7 +105,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value. 
@@ -137,14 +137,14 @@ When approved and ready to merge, a Pull Request should be squashed down to a si
 
 ## <a name="documentation"></a> Writing Documentation
 
-The Concerto-UI project uses [jsdoc][jsdoc] for all of its code
+The Cicero VSCode Extension project uses [jsdoc][jsdoc] for all of its code
 documentation.
 
 This means that all the docs are stored inline in the source code and so are kept in sync as it
 changes.
 
 This means that since we generate the documentation from the source code, we can easily provide
-version-specific documentation by simply checking out a version of Concerto-UI and running the build.
+version-specific documentation by simply checking out a version of Cicero VSCode Extension and running the build.
 
 ## License <a name="license"></a>
 
@@ -163,13 +163,13 @@ Accord Project documentation files are made available under the [Creative Common
 [node]: https://nodejs.org/en/
 [nvm]: https://github.com/creationix/nvm
 [nvm-windows]: https://github.com/coreybutler/nvm-windows
-[github]: https://github.com/accordproject/concerto-ui
+[github]: https://github.com/accordproject/cicero-vscode-extension
 [github-signup]: https://github.com/signup/free
-[github-issues]: https://github.com/accordproject/concerto-ui/issues
+[github-issues]: https://github.com/accordproject/cicero-vscode-extension/issues
 [github-forking]: http://help.github.com/forking
 [google]: https://google.github.io/styleguide/jsguide.html
 [commit]: https://github.com/commitizen/cz-cli
 [jsdoc]: http://usejsdoc.org/
 
-[apache]: https://github.com/accordproject/concerto-ui/blob/master/LICENSE
+[apache]: https://github.com/accordproject/cicero-vscode-extension/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. Some tests failed due to code vulnerabilities.

### Changes
- Modified markdown to be more appropriate with content of associated links
- Fixed typos and miscellaneous errors in punctuation and grammar

### Related Issues
- [Cicero Template Library Issue 257](https://github.com/accordproject/cicero-template-library/issues/257)
- Pull Request [#280](https://github.com/accordproject/cicero-template-library/pull/280)