### PR TITLE
feat(concerto.toLanguage.json): fix highlighting of acronyms - I13

### DIFF
--- a/client/syntaxes/concerto.tmLanguage.json
+++ b/client/syntaxes/concerto.tmLanguage.json
@@ -2250,6 +2250,11 @@
 					}
 				},
 				{
+					"name": "variable.other.readwrite.js",
+					"match": "([[:upper:]]*)(-)([_$[:digit:][:upper:]]*)(?![_$[:alnum:]])"
+
+				},
+				{
 					"name": "constant.other.js",
 					"match": "([[:upper:]][_$[:digit:][:upper:]]*)(?![_$[:alnum:]])"
 				},


### PR DESCRIPTION
Signed-off-by: adrijshikhar <adrijshikhar85@gmail.com>

# Issue #13 
fixes #13 
<OVERALL SUMMARY OF PULL REQUEST>

### Changes
- The commit adds a pattern matching for acronyms, for syntax highlighting 


### Before
<img width="268" alt="64984306-289c6200-d888-11e9-9c08-babd96affe14" src="https://user-images.githubusercontent.com/41939219/77214311-96299380-6b34-11ea-923a-9ee0ffb363d6.png">

### After

![Screenshot_20200321_052442](https://user-images.githubusercontent.com/41939219/77214318-9de93800-6b34-11ea-8f9c-27980981d7b6.png)


