### PR TITLE
feat(*): add validation of logo

### DIFF
--- a/client/logo.language-configuration.json
+++ b/client/logo.language-configuration.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "title": "Image configuration",
+    "properties": {
+        "languageServerExample.maxNumberOfProblems": {
+            "type": "number",
+            "default": 1,
+            "description": "Controls the maximum number of problems produced by the server."
+        }
+    }
+}

--- a/client/package.json
+++ b/client/package.json
@@ -50,7 +50,8 @@
 		"onLanguage:ergo",
 		"onLanguage:concerto",
 		"onLanguage:ciceroMark",
-		"onLanguage:markdown"
+		"onLanguage:markdown",
+		"onLanguage:image"
 	],
 	"main": "./out/src/extension",
 	"categories": [
@@ -90,6 +91,17 @@
 					".cto"
 				],
 				"configuration": "./concerto.language-configuration.json"
+			},
+			{
+				"id": "image",
+				"aliases": [
+					"PNG Image",
+					"Logo"
+				],
+				"extensions": [
+					".png"
+				],
+				"configuration": "./logo.language-configuration.json"
 			}
 		],
 		"grammars": [

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,7 +39,8 @@ export function activate(context: ExtensionContext) {
 			{scheme: 'file', language: 'ergo'}, 
 			{scheme: 'file', language: 'concerto'},
 			{scheme: 'file', language: 'ciceroMark'},
-			{scheme: 'file', language: 'markdown', pattern: '**/sample*.md'}
+			{scheme: 'file', language: 'markdown', pattern: '**/sample*.md'},
+			{scheme: 'file', language: 'image', pattern: 'logo.png'}
 		],
 		synchronize: {
 			// Synchronize the setting section 'languageServerExample' to the server


### PR DESCRIPTION
### Changes
These changes initialize the support for adding a validation which will verify if the correct type of image has been uploaded for the logo.

### Flags
- My approach is to simply detect the image in the working directory and then we can further validate it using functions in `cicero`.
- Currently, I am having some issues when I try to make VSCode detect my PNG file.

#### This is shown when I open my `PNG` file.
![Screenshot from 2020-04-06 23-43-13](https://user-images.githubusercontent.com/35191225/78593072-ab582f00-7863-11ea-9baa-8e7285fa7ec0.png)

#### This is shown when I open some other file, say `grammar.tem.md`
![Screenshot from 2020-04-06 23-44-05](https://user-images.githubusercontent.com/35191225/78593144-c75bd080-7863-11ea-9ce1-90ecea8e1264.png)

Ideally, it should also call https://github.com/accordproject/cicero-vscode-extension/blob/master/server/src/server.ts#L232 because I think this is called whenever the file is first opened or is changed.
