### PR TITLE
fix(concerto.tmLanguage): syntax highlighting of comments

### DIFF
--- a/client/syntaxes/concerto.tmLanguage.json
+++ b/client/syntaxes/concerto.tmLanguage.json
@@ -3024,7 +3024,7 @@
 					}
 				},
 				{
-					"begin": "(^[ \\t]+)?(?=//)",
+					"begin": "(^[ \\t]+)?(?<!:)(?=//)",
 					"beginCaptures": {
 						"1": {
 							"name": "punctuation.whitespace.comment.leading.js"


### PR DESCRIPTION
# Issue #59 
These changes fix the syntax highlighting for the comments in concerto grammar.

### Changes
- A regex lookbehind `(?<!:)` is introduced in the lexer to see if the `//` are **not** preceded by the a `:` (which is a part of the URL).

#### Before
![Screenshot from 2020-04-07 01-37-41](https://user-images.githubusercontent.com/35191225/78600328-671f5b80-7870-11ea-9f63-41c953e76220.png)

#### After
![Screenshot from 2020-04-07 01-33-02](https://user-images.githubusercontent.com/35191225/78600295-540c8b80-7870-11ea-946d-8ae0fb4f8dcf.png)


### Flags
- This may not be the best way to fix it hence, I am open to any suggestions. :)
