### PR TITLE
chore(version) Upgrade to Cicero 0.21.6 and Markdown Transform 0.12.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ log
 client/out
 server/out
 .DS_Store
+*.vsix

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,18 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.4.tgz",
-			"integrity": "sha512-xM5v1vahLORMC5H3RbzpCtOoCtoOhs8wO3X8ZPff0QI+pXMCkx9/XZPa9aNEJKVb0hwBr2PKzRwdylrdYExYdQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
+			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.4",
-				"@accordproject/ergo-engine": "0.21.4",
-				"@accordproject/markdown-cicero": "^0.12.6",
-				"@accordproject/markdown-common": "^0.12.6",
-				"@accordproject/markdown-html": "^0.12.6",
-				"@accordproject/markdown-slate": "^0.12.6",
-				"@accordproject/markdown-template": "^0.12.6",
+				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-engine": "0.21.5",
+				"@accordproject/markdown-cicero": "^0.12.7",
+				"@accordproject/markdown-common": "^0.12.7",
+				"@accordproject/markdown-html": "^0.12.7",
+				"@accordproject/markdown-slate": "^0.12.7",
+				"@accordproject/markdown-template": "^0.12.7",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -33,12 +33,12 @@
 			}
 		},
 		"@accordproject/cicero-engine": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-engine/-/cicero-engine-0.21.4.tgz",
-			"integrity": "sha512-g4FHkZk2RFKlScSHwpKr4q/gUE0a88PertVN+B1QaocN1fckSh7L6X8ZFydvjkaIKOUzekFDzttAIIMX/8CNpg==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-engine/-/cicero-engine-0.21.5.tgz",
+			"integrity": "sha512-LgN9e3rmFAUyuP7FlvwOz6aXPxkIpvo9H37F3QdihOcRTXz4MpZiGxYFr2IP9gIuEdszXSHUqcya8igU9cElqA==",
 			"requires": {
-				"@accordproject/cicero-core": "0.21.4",
-				"@accordproject/ergo-engine": "0.21.4",
+				"@accordproject/cicero-core": "0.21.5",
+				"@accordproject/ergo-engine": "0.21.5",
 				"moment-mini": "2.22.1"
 			}
 		},
@@ -230,9 +230,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.4.tgz",
-			"integrity": "sha512-xptuc0+S9WpEKhX1XHksc6GpDD1JPYjRy9W3VkQkOAYfV5ISe1pCN9xxeLKToQlTtCNsrjUyVo5+N+U/8JHqTA==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
+			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -254,31 +254,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.4.tgz",
-			"integrity": "sha512-LLqSb2hVkdQDe9HX+mar7yn0ZfHQToh+yOqTMVNyT0ft9mDZKPnp9GUlRD9/eSGSh6sZIOOI//HBZaH6IqVpbQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
+			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.4",
+				"@accordproject/ergo-compiler": "0.21.5",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.6.tgz",
-			"integrity": "sha512-8qs7BpIP4VN4Ljc71MXryeGv4UacvhpqF0tKlF8oCFtPFw51NDidoB5VNnftFKVoxwXVpgS+QC73rSdxkUQ/gA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
+			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-cicero": "0.12.6",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-cicero": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.6.tgz",
-			"integrity": "sha512-nXi/BfnF66Pzvn6lxBCtuB6CLL2v6xPfmNvb+psv4fnFvl/sKYzbBHPt1VOMUZIIOdTsmHNG/ac4qc96S4jQ1Q==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
+			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -287,49 +287,49 @@
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.6.tgz",
-			"integrity": "sha512-E1l/Fqa23nzc3sa/Ry2RDYR160WlcUuNYy6aEFzbJXmfeCyv0YpYXVgu6DD2dg8tnFChTZTErn61TnKRlronEA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
+			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.6.tgz",
-			"integrity": "sha512-Ey50zTBDjzwtPcfn/ckhTz9fPRq5T0rBH2zFpZ1baz79TTCqczo7QyHpvDiKNz+zKazqRwq9Ss5WVRxqYlp7RQ==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
+			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.6.tgz",
-			"integrity": "sha512-500aC0BiU5dNLaT201upbLAOWkxyVPeWu8HAfpQBE1SFBx75DehUCZd2nUOyEVthoTl9lychMO0xg1XuHmy4uw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
+			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.6.tgz",
-			"integrity": "sha512-mExTe4757syubAVFtDqixuKS8CUfFT1w2xInp49eve75BwCCXHb5lBVd4BqZ7363Skju8ORnePkL6NkvDtKivw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
+			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6"
+				"@accordproject/markdown-cicero": "0.12.7"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.6.tgz",
-			"integrity": "sha512-QpBDObzYkYvpTQaFzsL9I0+Z8YsyYZqIL7f7OzDegd64G+h+ELCgVaLo/9fuRsY8rDVjAh/ui2WHosMLkab1vw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
+			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-template": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-template": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
@@ -2558,9 +2558,9 @@
 			"integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "cicero-vscode-extension-client",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
-			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.6.tgz",
+			"integrity": "sha512-siTKTT3D1nzrqr5JqSaZyyJ+48gGX7dY1uxaqx+0J2/hUzmAEiBsujQRfqYYjxjoWYTM5YwOPV9UGnK+yOtnDQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.5",
-				"@accordproject/ergo-engine": "0.21.5",
-				"@accordproject/markdown-cicero": "^0.12.7",
-				"@accordproject/markdown-common": "^0.12.7",
-				"@accordproject/markdown-html": "^0.12.7",
-				"@accordproject/markdown-slate": "^0.12.7",
-				"@accordproject/markdown-template": "^0.12.7",
+				"@accordproject/ergo-compiler": "0.21.6",
+				"@accordproject/ergo-engine": "0.21.6",
+				"@accordproject/markdown-cicero": "^0.12.8",
+				"@accordproject/markdown-common": "^0.12.8",
+				"@accordproject/markdown-html": "^0.12.8",
+				"@accordproject/markdown-slate": "^0.12.8",
+				"@accordproject/markdown-template": "^0.12.8",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -33,12 +33,12 @@
 			}
 		},
 		"@accordproject/cicero-engine": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-engine/-/cicero-engine-0.21.5.tgz",
-			"integrity": "sha512-LgN9e3rmFAUyuP7FlvwOz6aXPxkIpvo9H37F3QdihOcRTXz4MpZiGxYFr2IP9gIuEdszXSHUqcya8igU9cElqA==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-engine/-/cicero-engine-0.21.6.tgz",
+			"integrity": "sha512-LdDPLoPzPw8jlOL3gnA6kGsM2o1vbDMDluXuaBDTeDtE5HrbCqKDwSnr5Qhqk85XDxI8MIWNCTs/2brtCOQJDQ==",
 			"requires": {
-				"@accordproject/cicero-core": "0.21.5",
-				"@accordproject/ergo-engine": "0.21.5",
+				"@accordproject/cicero-core": "0.21.6",
+				"@accordproject/ergo-engine": "0.21.6",
 				"moment-mini": "2.22.1"
 			}
 		},
@@ -230,9 +230,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
-			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.6.tgz",
+			"integrity": "sha512-JSK0V75nZ7tCMQIaaNfWCVLHGsyA20gRoR8F7xn1AY3bjizMebN5s6cYg8BY2ODM+yWvEJz/2Tvf7eYwRX1OLw==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -254,31 +254,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
-			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.6.tgz",
+			"integrity": "sha512-1uc9nhuUyV11I89rKFsY29+q+qUmPG6Haqw4bYV8gM+mTRmamvu0zYQsjhyAchVONyXtxHbn8GOkel++Z35ZyA==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-compiler": "0.21.6",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
-			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.8.tgz",
+			"integrity": "sha512-YPblroHXepJons2U98cIeFu3+Oi/kJOwQSQNLlU6pW1PxUXh8+S0v7+mPoxywT5X5bA1ktYU/ZipW1Z7D0pppA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-cicero": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
-			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.8.tgz",
+			"integrity": "sha512-fetAC2LEE6Vx/TQH8EDftEzdtawts4SpTPPcEsr+vy8/4wziNBBNNsL4vexf/EOl7NQyQ+mzu04lKLt9tMIiPA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -287,49 +287,49 @@
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
-			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.8.tgz",
+			"integrity": "sha512-YiZLJfUGUT4obT2hja4Q+I/kRMti+Ip5GFR4ZBli701ZY9b4I/hvf9cayG9qKyJSnODwHBuNh/RDeWEH0Ji8lw==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
-			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.8.tgz",
+			"integrity": "sha512-fEtHqV0vOhOHICDh9tYukDNVdclvLcCVc5l6fFf7MXwyJi5xOEbao+ckTPotjH3oxGc3PXWcnaQzjGfIXxp+Fg==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
-			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.8.tgz",
+			"integrity": "sha512-wINlXtKTsHWjybDa3vkL40mF7HFLGAHJV64tJ/d0Csp/enE7KwzRu2Xtq53CJKd6rfi2CcjSga1Jx9rG2zimcA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
-			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.8.tgz",
+			"integrity": "sha512-yl6cune3+FfuQdsOgeolC4rpL6JdVDs3soGK0paRjZtbqb/efu7+JhGdl/px+nh/idCbhKH3MoACbkpReNmAvg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7"
+				"@accordproject/markdown-cicero": "0.12.8"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
-			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.8.tgz",
+			"integrity": "sha512-xJW4QvrdAWz3Rvp5YtkrPVfZ8CFs2oluJ6F+bTZPWiDaleNvrjwAlpGbv1avWaY2beqsQ6vjTmilX4RvtA0G0w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-template": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-template": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,12 +18,12 @@
 		"vscode-test": "^1.3.0"
 	},
 	"dependencies": {
-		"@accordproject/cicero-core": "^0.21.4",
-		"@accordproject/cicero-engine": "^0.21.4",
+		"@accordproject/cicero-core": "^0.21.5",
+		"@accordproject/cicero-engine": "^0.21.5",
 		"@accordproject/concerto-core": "^0.82.8",
 		"@accordproject/concerto-tools": "^0.82.8",
-		"@accordproject/markdown-it-cicero": "^0.12.6",
-		"@accordproject/markdown-it-template": "^0.12.6",
+		"@accordproject/markdown-it-cicero": "^0.12.7",
+		"@accordproject/markdown-it-template": "^0.12.7",
 		"mermaid": "^8.7.0",
 		"vscode-languageclient": "^6.1.3"
 	}

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
 	"description": "Accord Project extension for Visual Studio Code, providing tools for template development.",
 	"author": "Accord Project",
 	"license": "Apache-2.0",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"publisher": "accordproject",
 	"repository": {
 		"type": "git",
@@ -18,12 +18,12 @@
 		"vscode-test": "^1.3.0"
 	},
 	"dependencies": {
-		"@accordproject/cicero-core": "^0.21.5",
-		"@accordproject/cicero-engine": "^0.21.5",
+		"@accordproject/cicero-core": "^0.21.6",
+		"@accordproject/cicero-engine": "^0.21.6",
 		"@accordproject/concerto-core": "^0.82.8",
 		"@accordproject/concerto-tools": "^0.82.8",
-		"@accordproject/markdown-it-cicero": "^0.12.7",
-		"@accordproject/markdown-it-template": "^0.12.7",
+		"@accordproject/markdown-it-cicero": "^0.12.8",
+		"@accordproject/markdown-it-template": "^0.12.8",
 		"mermaid": "^8.7.0",
 		"vscode-languageclient": "^6.1.3"
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cicero-vscode-extension",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Accord Project extension for Visual Studio Code, providing tools for template development.",
 	"author": "Accord Project",
 	"license": "Apache-2.0",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"icon": "icon.png",
 	"repository": {
 		"type": "git",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -5,18 +5,18 @@
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.4.tgz",
-			"integrity": "sha512-xM5v1vahLORMC5H3RbzpCtOoCtoOhs8wO3X8ZPff0QI+pXMCkx9/XZPa9aNEJKVb0hwBr2PKzRwdylrdYExYdQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
+			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.4",
-				"@accordproject/ergo-engine": "0.21.4",
-				"@accordproject/markdown-cicero": "^0.12.6",
-				"@accordproject/markdown-common": "^0.12.6",
-				"@accordproject/markdown-html": "^0.12.6",
-				"@accordproject/markdown-slate": "^0.12.6",
-				"@accordproject/markdown-template": "^0.12.6",
+				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-engine": "0.21.5",
+				"@accordproject/markdown-cicero": "^0.12.7",
+				"@accordproject/markdown-common": "^0.12.7",
+				"@accordproject/markdown-html": "^0.12.7",
+				"@accordproject/markdown-slate": "^0.12.7",
+				"@accordproject/markdown-template": "^0.12.7",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -78,9 +78,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.4.tgz",
-			"integrity": "sha512-xptuc0+S9WpEKhX1XHksc6GpDD1JPYjRy9W3VkQkOAYfV5ISe1pCN9xxeLKToQlTtCNsrjUyVo5+N+U/8JHqTA==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
+			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -102,31 +102,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.4.tgz",
-			"integrity": "sha512-LLqSb2hVkdQDe9HX+mar7yn0ZfHQToh+yOqTMVNyT0ft9mDZKPnp9GUlRD9/eSGSh6sZIOOI//HBZaH6IqVpbQ==",
+			"version": "0.21.5",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
+			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.4",
+				"@accordproject/ergo-compiler": "0.21.5",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.6.tgz",
-			"integrity": "sha512-8qs7BpIP4VN4Ljc71MXryeGv4UacvhpqF0tKlF8oCFtPFw51NDidoB5VNnftFKVoxwXVpgS+QC73rSdxkUQ/gA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
+			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-cicero": "0.12.6",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-cicero": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.6.tgz",
-			"integrity": "sha512-nXi/BfnF66Pzvn6lxBCtuB6CLL2v6xPfmNvb+psv4fnFvl/sKYzbBHPt1VOMUZIIOdTsmHNG/ac4qc96S4jQ1Q==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
+			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -135,49 +135,49 @@
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.6.tgz",
-			"integrity": "sha512-E1l/Fqa23nzc3sa/Ry2RDYR160WlcUuNYy6aEFzbJXmfeCyv0YpYXVgu6DD2dg8tnFChTZTErn61TnKRlronEA==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
+			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.6.tgz",
-			"integrity": "sha512-Ey50zTBDjzwtPcfn/ckhTz9fPRq5T0rBH2zFpZ1baz79TTCqczo7QyHpvDiKNz+zKazqRwq9Ss5WVRxqYlp7RQ==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
+			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.6.tgz",
-			"integrity": "sha512-500aC0BiU5dNLaT201upbLAOWkxyVPeWu8HAfpQBE1SFBx75DehUCZd2nUOyEVthoTl9lychMO0xg1XuHmy4uw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
+			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.6.tgz",
-			"integrity": "sha512-mExTe4757syubAVFtDqixuKS8CUfFT1w2xInp49eve75BwCCXHb5lBVd4BqZ7363Skju8ORnePkL6NkvDtKivw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
+			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.6"
+				"@accordproject/markdown-cicero": "0.12.7"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.6",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.6.tgz",
-			"integrity": "sha512-QpBDObzYkYvpTQaFzsL9I0+Z8YsyYZqIL7f7OzDegd64G+h+ELCgVaLo/9fuRsY8rDVjAh/ui2WHosMLkab1vw==",
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
+			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.6",
-				"@accordproject/markdown-common": "0.12.6",
-				"@accordproject/markdown-it-template": "0.12.6",
+				"@accordproject/markdown-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-it-template": "0.12.7",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",
@@ -1617,9 +1617,9 @@
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"uri-js": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,22 +1,22 @@
 {
 	"name": "cicero-vscode-extension-server",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@accordproject/cicero-core": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.5.tgz",
-			"integrity": "sha512-rRNNv39UF6RwOwxkZenvQK7j3IE4LW9syTyFkIqrXBoJTi/yDqhYBQcGPFSGoz3KBAyS4PcdVRIAlLflUAWJYQ==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-0.21.6.tgz",
+			"integrity": "sha512-siTKTT3D1nzrqr5JqSaZyyJ+48gGX7dY1uxaqx+0J2/hUzmAEiBsujQRfqYYjxjoWYTM5YwOPV9UGnK+yOtnDQ==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
-				"@accordproject/ergo-compiler": "0.21.5",
-				"@accordproject/ergo-engine": "0.21.5",
-				"@accordproject/markdown-cicero": "^0.12.7",
-				"@accordproject/markdown-common": "^0.12.7",
-				"@accordproject/markdown-html": "^0.12.7",
-				"@accordproject/markdown-slate": "^0.12.7",
-				"@accordproject/markdown-template": "^0.12.7",
+				"@accordproject/ergo-compiler": "0.21.6",
+				"@accordproject/ergo-engine": "0.21.6",
+				"@accordproject/markdown-cicero": "^0.12.8",
+				"@accordproject/markdown-common": "^0.12.8",
+				"@accordproject/markdown-html": "^0.12.8",
+				"@accordproject/markdown-slate": "^0.12.8",
+				"@accordproject/markdown-template": "^0.12.8",
 				"axios": "0.19.0",
 				"debug": "4.1.0",
 				"ietf-language-tag-regex": "0.0.5",
@@ -78,9 +78,9 @@
 			}
 		},
 		"@accordproject/ergo-compiler": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.5.tgz",
-			"integrity": "sha512-PAmyXtN7vizyYJ56TBrAZHwb5BTvMnWY4q8K+nkckhllxqLU7S4npc/ysAbfFnbMgiDO+rWylw/AiHtnTmXSow==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-compiler/-/ergo-compiler-0.21.6.tgz",
+			"integrity": "sha512-JSK0V75nZ7tCMQIaaNfWCVLHGsyA20gRoR8F7xn1AY3bjizMebN5s6cYg8BY2ODM+yWvEJz/2Tvf7eYwRX1OLw==",
 			"requires": {
 				"@accordproject/concerto-core": "0.82.8",
 				"acorn": "5.1.2",
@@ -102,31 +102,31 @@
 			}
 		},
 		"@accordproject/ergo-engine": {
-			"version": "0.21.5",
-			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.5.tgz",
-			"integrity": "sha512-pZYoTgEuoxuQr3d5K+fXS8UxrtL+IstgaMS74DNS2WLL1J5WBJFEksn3yA9IBYDwk1ADbqZfa6PaotLi18S15g==",
+			"version": "0.21.6",
+			"resolved": "https://registry.npmjs.org/@accordproject/ergo-engine/-/ergo-engine-0.21.6.tgz",
+			"integrity": "sha512-1uc9nhuUyV11I89rKFsY29+q+qUmPG6Haqw4bYV8gM+mTRmamvu0zYQsjhyAchVONyXtxHbn8GOkel++Z35ZyA==",
 			"requires": {
-				"@accordproject/ergo-compiler": "0.21.5",
+				"@accordproject/ergo-compiler": "0.21.6",
 				"moment-mini": "2.22.1",
 				"vm2": "3.5.0"
 			}
 		},
 		"@accordproject/markdown-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.7.tgz",
-			"integrity": "sha512-ddDkYdPZLGo3FmfArfriCpIAaV/nehHj8zifm4l1u4jdFzzZ3m4yUPZ4LFxWYvqVRklbNJhV8ZpOEd5riXYoWQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-cicero/-/markdown-cicero-0.12.8.tgz",
+			"integrity": "sha512-YPblroHXepJons2U98cIeFu3+Oi/kJOwQSQNLlU6pW1PxUXh8+S0v7+mPoxywT5X5bA1ktYU/ZipW1Z7D0pppA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-cicero": "0.12.7",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-cicero": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"winston": "3.2.1"
 			}
 		},
 		"@accordproject/markdown-common": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.7.tgz",
-			"integrity": "sha512-r+KKRL2u+3YHBaeMaDbWTXYnna0ylYHDO0zxEAWXyK2gbQkl6PalW+1GTZSdGx6j2sDwtTIKQCLfQnZiyMBs9w==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-common/-/markdown-common-0.12.8.tgz",
+			"integrity": "sha512-fetAC2LEE6Vx/TQH8EDftEzdtawts4SpTPPcEsr+vy8/4wziNBBNNsL4vexf/EOl7NQyQ+mzu04lKLt9tMIiPA==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
 				"markdown-it": "^11.0.0",
@@ -135,49 +135,49 @@
 			}
 		},
 		"@accordproject/markdown-html": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.7.tgz",
-			"integrity": "sha512-z1alqV238Ok9JNR2p/IEs1et4LMcPtOIZ0QuPpAm9x6y8n2ScK98zTD7ko94J5/YnZ2m4g80HHY8UySMHXeA+g==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-html/-/markdown-html-0.12.8.tgz",
+			"integrity": "sha512-YiZLJfUGUT4obT2hja4Q+I/kRMti+Ip5GFR4ZBli701ZY9b4I/hvf9cayG9qKyJSnODwHBuNh/RDeWEH0Ji8lw==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
 				"jsdom": "^15.2.1",
 				"type-of": "^2.0.1"
 			}
 		},
 		"@accordproject/markdown-it-cicero": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.7.tgz",
-			"integrity": "sha512-jGUQ8lfBGZuh68MDweag1y1fwo1kQF/8nBPvuW2MHJpKOg1E+n38P3EuxXOumh0iglbtD8pBGC4qm0OMvVP+rQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-cicero/-/markdown-it-cicero-0.12.8.tgz",
+			"integrity": "sha512-fEtHqV0vOhOHICDh9tYukDNVdclvLcCVc5l6fFf7MXwyJi5xOEbao+ckTPotjH3oxGc3PXWcnaQzjGfIXxp+Fg==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-it-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.7.tgz",
-			"integrity": "sha512-JqqHv/ls9wr6Xrj0VAjzjUQdbVuPb7Dxmif1EIyHrvnAAXIWVleqMYLeVgXD9QZf67Whv5vkK0vf+9OmtbomXA==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-it-template/-/markdown-it-template-0.12.8.tgz",
+			"integrity": "sha512-wINlXtKTsHWjybDa3vkL40mF7HFLGAHJV64tJ/d0Csp/enE7KwzRu2Xtq53CJKd6rfi2CcjSga1Jx9rG2zimcA==",
 			"requires": {
 				"markdown-it": "^11.0.0"
 			}
 		},
 		"@accordproject/markdown-slate": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.7.tgz",
-			"integrity": "sha512-Rl2gVoyrOM/n7+nwRlmYBXpw4HEw3/DPU2/YGzCPPX/vFD8IB0982KNB1fBgXsNHZEOoUOaD1G8ruRRWE+Q5nQ==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-slate/-/markdown-slate-0.12.8.tgz",
+			"integrity": "sha512-yl6cune3+FfuQdsOgeolC4rpL6JdVDs3soGK0paRjZtbqb/efu7+JhGdl/px+nh/idCbhKH3MoACbkpReNmAvg==",
 			"requires": {
-				"@accordproject/markdown-cicero": "0.12.7"
+				"@accordproject/markdown-cicero": "0.12.8"
 			}
 		},
 		"@accordproject/markdown-template": {
-			"version": "0.12.7",
-			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.7.tgz",
-			"integrity": "sha512-K8q0lAoDmdou8NHYWt7ASPfdn8XU/s5obrFm3rrKJveolQIUVxCNrZzv+qSwNm72JdOX/sNDQ67tNuqaDbFQSg==",
+			"version": "0.12.8",
+			"resolved": "https://registry.npmjs.org/@accordproject/markdown-template/-/markdown-template-0.12.8.tgz",
+			"integrity": "sha512-xJW4QvrdAWz3Rvp5YtkrPVfZ8CFs2oluJ6F+bTZPWiDaleNvrjwAlpGbv1avWaY2beqsQ6vjTmilX4RvtA0G0w==",
 			"requires": {
 				"@accordproject/concerto-core": "^0.82.8",
-				"@accordproject/markdown-cicero": "0.12.7",
-				"@accordproject/markdown-common": "0.12.7",
-				"@accordproject/markdown-it-template": "0.12.7",
+				"@accordproject/markdown-cicero": "0.12.8",
+				"@accordproject/markdown-common": "0.12.8",
+				"@accordproject/markdown-it-template": "0.12.8",
 				"markdown-it": "^11.0.0",
 				"moment-mini": "2.22.1",
 				"parsimmon": "^1.13.0",

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,11 @@
 		"url": "https://github.com/accordproject/cicero-vscode-extension"
 	},
 	"dependencies": {
-		"@accordproject/cicero-core": "^0.21.4",
+		"@accordproject/cicero-core": "^0.21.5",
 		"@accordproject/concerto-core": "^0.82.8",
-		"@accordproject/ergo-compiler": "^0.21.4",
-		"@accordproject/ergo-engine": "^0.21.4",
-		"@accordproject/markdown-template": "^0.12.6",
+		"@accordproject/ergo-compiler": "^0.21.5",
+		"@accordproject/ergo-engine": "^0.21.5",
+		"@accordproject/markdown-template": "^0.12.7",
 		"fast-safe-stringify": "2.0.6",
 		"glob": "^7.1.6",
 		"vscode-languageserver": "^6.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cicero-vscode-extension-server",
 	"description": "A language server for Accord Project templates",
-	"version": "0.21.14",
+	"version": "0.21.15",
 	"license": "Apache-2.0",
 	"engines": {
 		"node": "*"
@@ -11,11 +11,11 @@
 		"url": "https://github.com/accordproject/cicero-vscode-extension"
 	},
 	"dependencies": {
-		"@accordproject/cicero-core": "^0.21.5",
+		"@accordproject/cicero-core": "^0.21.6",
 		"@accordproject/concerto-core": "^0.82.8",
-		"@accordproject/ergo-compiler": "^0.21.5",
-		"@accordproject/ergo-engine": "^0.21.5",
-		"@accordproject/markdown-template": "^0.12.7",
+		"@accordproject/ergo-compiler": "^0.21.6",
+		"@accordproject/ergo-engine": "^0.21.6",
+		"@accordproject/markdown-template": "^0.12.8",
 		"fast-safe-stringify": "2.0.6",
 		"glob": "^7.1.6",
 		"vscode-languageserver": "^6.1.1",


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes
- Upgrade to latest cicero `0.21.6`
- Upgrade to latest markdown transform `0.12.8` including bug fixes to markdown-it extension
