### PR TITLE
fix(cpu): remove infinite loop in language server

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -94,8 +94,8 @@ function getTemplateRoot(pathStr, textDocument, diagnosticMap) {
         }
         catch(err) {
             // connection.console.log( `- exception ${err}`);
-            currentPath = path.normalize(path.join(currentPath, '..'));
         }
+        currentPath = path.normalize(path.join(currentPath, '..'));
     }
 
     connection.console.log( `Failed to find template path for ${pathStr}`);


### PR DESCRIPTION
If you use the extension to open a folder that has a `package.json` file in it, but that `package.json` file does not contain a top-level `accordproject` key, then the language server eats 100% CPU spinning in a loop due to a logic bug. This change fixes that logic bug.

Signed-off-by: Simon Stone <Simon.Stone@docusign.com>