### PR TITLE
Add parse command to context menu

### DIFF
--- a/client/src/commandHandlers.ts
+++ b/client/src/commandHandlers.ts
@@ -307,6 +307,60 @@ export async function triggerClause(file: vscode.Uri) {
 	return false;
 }
 
+export async function parseClause(file: vscode.Uri) {
+	try {
+		if(!checkTemplate(file)) {
+			return false;
+		}
+
+		outputChannel.show();
+        
+		const optionsPath = path.join(file.path,"options.json")
+		var options = null
+		if(fs.existsSync(optionsPath)){
+			options = JSON.parse(fs.readFileSync(optionsPath,"utf-8"))
+		}
+
+		const parseOptions = options?.parse;
+		
+		await vscode.workspace.saveAll();
+		const template = await Template.fromDirectory(file.path);
+		const clause = new Clause(template);
+		const samplePath = (parseOptions?.samplePath)?path.join(file.path, 'text', parseOptions?.samplePath): path.join(file.path, 'text', 'sample.md');
+
+		if (!fs.existsSync(samplePath)) {
+			vscode.window.showErrorMessage(`Cannot parse: ${samplePath} file was not found.`);
+			return false;
+		}
+
+		const sampleText = fs.readFileSync(samplePath, 'utf8');
+		clause.parse(sampleText, parseOptions?.currentTime, parseOptions?.utcOffset, samplePath);
+
+		outputChannel.appendLine('template');
+		outputChannel.appendLine('========');
+		outputChannel.appendLine(template.getIdentifier());
+		outputChannel.appendLine('');
+
+		outputChannel.appendLine(`${samplePath} parse result`);
+		outputChannel.appendLine('======================');
+		outputChannel.appendLine(JSON.stringify(clause.getData(),null,2));
+		outputChannel.appendLine('');
+
+		if(parseOptions?.outputPath) {
+			outputChannel.appendLine(`Writing output to ${parseOptions?.outputPath}....`);
+			fs.writeFileSync(path.join(file.fsPath,parseOptions?.outputPath), JSON.stringify(clause.getData(),null,2));
+		    outputChannel.appendLine(`Output written to ${parseOptions?.outputPath}`);
+			outputChannel.appendLine('');
+		}
+
+		return true;
+	} catch (error) {
+		vscode.window.showErrorMessage( `Failed to parse clause ${error}`);
+	}
+
+	return false;
+}
+
 async function getHtml() {
 
 	let html = 'To display preview please open a grammar.tem.md or a *.cto file.';

--- a/client/src/commandHandlers.ts
+++ b/client/src/commandHandlers.ts
@@ -307,52 +307,66 @@ export async function triggerClause(file: vscode.Uri) {
 	return false;
 }
 
+function getProjectRoot(pathStr) {
+
+    let currentPath = pathStr;
+
+    while(currentPath !== '/' && currentPath.split(":").pop() !== '\\') {
+        // connection.console.log( `- ${currentPath}`);
+
+        try{
+            if(fs.existsSync(currentPath + '/package.json'))
+			    return currentPath;
+        }
+        catch(err) {
+            // connection.console.log( `- exception ${err}`);
+        }
+        currentPath = path.normalize(path.join(currentPath, '..'));
+    }
+    return path.basename(path.dirname(pathStr));
+}
+
 export async function parseClause(file: vscode.Uri) {
-	try {
-		if(!checkTemplate(file)) {
-			return false;
-		}
-
-		outputChannel.show();
-        
-		const optionsPath = path.join(file.path,"options.json")
-		var options = null
-		if(fs.existsSync(optionsPath)){
-			options = JSON.parse(fs.readFileSync(optionsPath,"utf-8"))
-		}
-
-		const parseOptions = options?.parse;
-		
+	try {	
+		const templateDirectory = getProjectRoot(file.fsPath);
 		await vscode.workspace.saveAll();
-		const template = await Template.fromDirectory(file.path);
-		const clause = new Clause(template);
-		const samplePath = (parseOptions?.samplePath)?path.join(file.path, 'text', parseOptions?.samplePath): path.join(file.path, 'text', 'sample.md');
 
-		if (!fs.existsSync(samplePath)) {
-			vscode.window.showErrorMessage(`Cannot parse: ${samplePath} file was not found.`);
-			return false;
-		}
+		var panel = vscode.window.createWebviewPanel(
+			'parseInput',
+			'Parse Input',
+			vscode.ViewColumn.Beside,
+			{
+			  // Enable scripts in the webview
+			  enableScripts: true
+			}
+		);
 
-		const sampleText = fs.readFileSync(samplePath, 'utf8');
-		clause.parse(sampleText, parseOptions?.currentTime, parseOptions?.utcOffset, samplePath);
+		panel.webview.html = await getParseWebviewContent(path.relative(templateDirectory,file.path));
 
-		outputChannel.appendLine('template');
-		outputChannel.appendLine('========');
-		outputChannel.appendLine(template.getIdentifier());
-		outputChannel.appendLine('');
+		panel.webview.onDidReceiveMessage(
+			async (message) => {
+			  const {samplePath,outputPath,utcOffset,currentTime} = message;
+			  const template = await Template.fromDirectory(templateDirectory);
+		      const clause = new Clause(template);
+			  const sampleText = fs.readFileSync(path.resolve(templateDirectory,samplePath), 'utf8');
 
-		outputChannel.appendLine(`${samplePath} parse result`);
-		outputChannel.appendLine('======================');
-		outputChannel.appendLine(JSON.stringify(clause.getData(),null,2));
-		outputChannel.appendLine('');
+		      clause.parse(sampleText, currentTime, utcOffset, path.resolve(templateDirectory,samplePath));	  
 
-		if(parseOptions?.outputPath) {
-			outputChannel.appendLine(`Writing output to ${parseOptions?.outputPath}....`);
-			fs.writeFileSync(path.join(file.fsPath,parseOptions?.outputPath), JSON.stringify(clause.getData(),null,2));
-		    outputChannel.appendLine(`Output written to ${parseOptions?.outputPath}`);
-			outputChannel.appendLine('');
-		}
+			  outputChannel.show();
 
+			  outputChannel.appendLine(`${samplePath} parse result`);
+		      outputChannel.appendLine('======================');
+		      outputChannel.appendLine(JSON.stringify(clause.getData(),null,2));
+		      outputChannel.appendLine('');
+
+
+			  fs.writeFileSync( path.resolve(templateDirectory,outputPath), JSON.stringify(clause.getData(),null,2));
+			  outputChannel.appendLine(`Output written to ${outputPath}`);
+			  outputChannel.appendLine('');
+			},
+			null
+	    )
+		
 		return true;
 	} catch (error) {
 		vscode.window.showErrorMessage( `Failed to parse clause ${error}`);
@@ -361,7 +375,7 @@ export async function parseClause(file: vscode.Uri) {
 	return false;
 }
 
-async function getHtml() {
+async function getPreviewHtml() {
 
 	let html = 'To display preview please open a grammar.tem.md or a *.cto file.';
 
@@ -407,9 +421,164 @@ ${result.mermaid}
 	return html;
 }
 
+function getParseWebviewContent(samplePath){
+    
+    const defaultOutPath = samplePath+".json";
+	const html = getParseWebviewHtml(samplePath,defaultOutPath);
 
-export async function getWebviewContent() {
-	const html = await getHtml();
+	const styles = `<style>
+	* {
+	  box-sizing: border-box;
+	}
+	
+	input, select, textarea {
+	  width: 80%;
+	  padding: 12px;
+	  border-radius: 4px;
+	  resize: vertical;
+	}
+	
+	label {
+	  padding: 12px 12px 12px 0;
+	  display: inline-block;
+	}
+	
+	button {
+	  background-color: #04AA6D;
+	  color: white;
+	  padding: 12px 20px;
+	  border: none;
+	  border-radius: 4px;
+	  cursor: pointer;
+	  float: left;
+	}
+	
+	button:hover {
+	  background-color: #45a049;
+	}
+	
+	.container {
+	  border-radius: 5px;
+	  padding: 20px;
+	}
+	
+	.col-25 {
+	  float: left;
+	  width: 25%;
+	  margin-top: 6px;
+	}
+	
+	.col-75 {
+	  float: left;
+	  width: 75%;
+	  margin-top: 6px;
+	}
+	
+	/* Clear floats after the columns */
+	.row:after {
+	  content: "";
+	  display: table;
+	  clear: both;
+	}
+
+	.button{
+		width: 30%;
+	}
+
+	.button-container{
+		text-align: center;
+	}
+	
+	@media screen and (max-width: 600px) {
+	   input[type=submit] {
+		width: 100%;
+		margin-top: 0;
+	  }
+	}
+	</style>`
+
+	return `<!DOCTYPE html>
+	<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Accord Project</title>
+		<style>${styles}</style>
+	</head>
+	<body>
+       ${html}
+	</body>
+	<script>
+		let btn = document.getElementById("button");
+		const vscode = acquireVsCodeApi();
+        btn.addEventListener('click', event => {
+			vscode.postMessage({
+				command: 'parse',
+				outputPath: document.getElementById("outputPath").value,
+				samplePath: document.getElementById("samplePath").value,
+				utcOffset: document.getElementById("utcOffset").value,
+				currentTime: document.getElementById("currentTime").value,
+			})
+        });
+
+    </script>
+	</html>`;
+}
+
+function getParseWebviewHtml(defaultSamplePath,defaultOutPath){
+
+	return `
+	<div class="container">
+	<div class="row">
+	<h4>*Paths mentioned here are relative to the template directory</h4>
+    </div>
+	  <div class="row">
+		<div class="col-25">
+		  <label for="samplePath">Sample Path</label>
+		</div>
+		<div class="col-75">
+		  <input type="text" id="samplePath" name="samplePath" placeholder="Choose Sample Path" value=${defaultSamplePath} >
+		</div>
+	  </div>
+	  <br>
+	  <div class="row">
+		<div class="col-25">
+		  <label for="outputPath">Ouput Path</label>
+		</div>
+		<div class="col-75">
+		  <input type="text" id="outputPath" name="outputPath" placeholder="Choose Output Path" value=${defaultOutPath}>
+		</div>
+	  </div>
+	  <br>
+	  <div class="row">
+		<div class="col-25">
+		  <label for="utcOffset">UTC Offset</label>
+		</div>
+		<div class="col-75">
+		  <input type="number" id="utcOffset" name="utcOffset" placeholder="UTC Offset" value="0">
+		</div>
+	  </div>
+	  <br>
+	  <div class="row">
+		<div class="col-25">
+		  <label for="currentTime">Current Time</label>
+		</div>
+		<div class="col-75">
+		  <input type="text" id="currentTime" name="currentTime" placeholder="Current Time">
+		</div>
+	  </div>	  
+	  <br>
+	  <r>
+	  <br>
+	  <div class="row">
+	  <button type="submit" id="button" class="button">Parse</button>
+	  </div>
+	</div>`
+
+}
+
+export async function getPreviewWebviewContent() {
+	const html = await getPreviewHtml();
 
 	const styles = `
 	table, th, td {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -29,7 +29,8 @@ import {
 	exportClassDiagram,
 	triggerClause,
 	getWebviewContent,
-	setOutputChannel
+	setOutputChannel,
+	parseClause
 } from './commandHandlers';
 
 let client: LanguageClient;
@@ -111,6 +112,8 @@ export function activate(context: vscode.ExtensionContext) {
 		.registerCommand('cicero-vscode-extension.exportClassDiagram', exportClassDiagram));
 	context.subscriptions.push(vscode.commands
 		.registerCommand('cicero-vscode-extension.triggerClause', triggerClause));
+	context.subscriptions.push(vscode.commands
+		.registerCommand('cicero-vscode-extension.parseClause', parseClause));
 
 	let currentPanel: vscode.WebviewPanel | undefined = undefined;
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -28,7 +28,7 @@ import {
 	downloadModels,
 	exportClassDiagram,
 	triggerClause,
-	getWebviewContent,
+	getPreviewWebviewContent,
 	setOutputChannel,
 	parseClause
 } from './commandHandlers';
@@ -37,7 +37,7 @@ let client: LanguageClient;
 
 async function onDocumentChange(event) {
 	if (event.document.languageId === 'ciceroMark' || event.document.languageId === 'concerto') {
-		return getWebviewContent();;
+		return getPreviewWebviewContent();;
 	}
 
 	return null;
@@ -134,7 +134,7 @@ export function activate(context: vscode.ExtensionContext) {
 					  }
 				);
 
-				currentPanel.webview.html = await getWebviewContent();
+				currentPanel.webview.html = await getPreviewWebviewContent();
 
 				// Reset when the current panel is closed
 				currentPanel.onDidDispose(

--- a/client/src/test/suite/extension.test.ts
+++ b/client/src/test/suite/extension.test.ts
@@ -81,6 +81,14 @@ suite('Extension Tests', () => {
     });
   });
 
+  test('should execute parseClause command', () => {
+    const uri = vscode.Uri.file(path.join(rootPath, '../test/data/valid/template/acceptance-of-delivery'));
+
+    vscode.commands.executeCommand('cicero-vscode-extension.parseClause', uri).then((result) => {
+      assert.ok(result);
+    });
+  });
+
   test('should execute showPreview command', () => {
     vscode.commands.executeCommand('cicero-vscode-extension.showPreview').then((result) => {
       assert.ok(result);

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 					"group": "AccordProject@4"
 				},
 				{
-					"when": "explorerResourceIsFolder",
+					"when": "resourceLangId == ciceroMark || resourceLangId == markdown",
 					"command": "cicero-vscode-extension.parseClause",
 					"group": "AccordProject@5"
 				},

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"onCommand:cicero-vscode-extension.downloadModels",
 		"onCommand:cicero-vscode-extension.viewClassDiagram",
 		"onCommand:cicero-vscode-extension.triggerClause",
+		"onCommand:cicero-vscode-extension.parseClause",
 		"onCommand:cicero-vscode-extension.showPreview"
 	],
 	"main": "./client/out/extension",
@@ -121,6 +122,11 @@
 				"category": "Accord Project"
 			},
 			{
+				"command": "cicero-vscode-extension.parseClause",
+				"title": "Parse",
+				"category": "Accord Project"
+			},
+			{
 				"command": "cicero-vscode-extension.showPreview",
 				"title": "Open Preview",
 				"icon": {
@@ -153,9 +159,14 @@
 					"group": "AccordProject@4"
 				},
 				{
+					"when": "explorerResourceIsFolder",
+					"command": "cicero-vscode-extension.parseClause",
+					"group": "AccordProject@5"
+				},
+				{
 					"when": "resourceLangId == ciceroMark || resourceLangId == concerto",
 					"command": "cicero-vscode-extension.showPreview",
-					"group": "AccordProject@5"
+					"group": "AccordProject@6"
 				}
 			],
 			"editor/title": [
@@ -180,6 +191,10 @@
 				},
 				{
 					"command": "cicero-vscode-extension.triggerClause",
+					"when": "false"
+				},
+				{
+					"command": "cicero-vscode-extension.parseClause",
 					"when": "false"
 				}
 			]


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #<CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- add ``parseClause`` function to ``commandHandlers.ts``
- register ``Parse`` to the contextMenu

### Options.json format
#### Defaults
- samplePath: ``sample.md``
- outputpath: ``none``
<!--- Provide context or concerns a reviewer should be aware of -->
```
{
    "parse":{
        "samplePath":"sample-options.md",
        "outputPath":"parseOutput.json",
        "currentTime": "...",
        "utcOffset": "..."
    }
}
```

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

https://user-images.githubusercontent.com/76606666/172622292-82a3c81c-0c78-47b5-9667-57486b29de42.mov

### Areas of discussion
- Improving ``options.json`` format
- Whether something similar can be done for other commands as well

### Related Issues
- Issue #72 

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`