### PR TITLE
Enable read/write ability to remote repositories

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,18 @@
 				"type": "npm",
 				"script": "watch"
 			}
+		},		
+		{
+			"name": "Run Web Extension in VS Code",
+			"type": "extensionHost",
+			"debugWebWorkerHost": true,
+			"request": "launch",
+			"args": [
+			  "--extensionDevelopmentPath=${workspaceFolder}",
+			  "--extensionDevelopmentKind=web"
+			],
+			"outFiles": ["${workspaceFolder}/dist/web/**/*.js"],
+			"preLaunchTask": "npm: watch-web"
 		},
 		{
 			"type": "node",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,13 @@
 			"problemMatcher": [
 				"$tsc-watch"
 			]
+		},
+		{
+			"type": "npm",
+			"script": "watch-web",
+			"group": "build",
+			"isBackground": true,
+			"problemMatcher": ["$ts-webpack-watch"]
 		}
 	]
 }

--- a/client/src/filewriter.ts
+++ b/client/src/filewriter.ts
@@ -14,7 +14,7 @@
 
 'use strict';
 
-import { URI } from 'vscode-uri';
+import { URI, Utils } from 'vscode-uri';
 
 const vscode = require('vscode');
 const path = require('path');
@@ -105,12 +105,12 @@ export default class FileWriter extends Writer {
 
         let filePath = this.outputDirectory;
         if (this.relativeDir) {
-            filePath = path.resolve(filePath, this.relativeDir);
+            filePath = Utils.resolvePath(filePath, this.relativeDir);
         }
-        filePath = path.resolve(filePath, this.fileName);
+        filePath = Utils.resolvePath(filePath, this.fileName);
 
         //console.log('Writing to ' + filePath );
-        vscode.workspace.fs.writeFile(URI.file(filePath), Buffer.from(this.getBuffer(),'utf-8'));
+        vscode.workspace.fs.writeFile(filePath, Buffer.from(this.getBuffer(),'utf-8'));
 
         this.fileName = null;
         this.relativeDir = null;

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
 		"compile": "tsc -b",
 		"watch": "tsc -b -w",
 		"web-compile": "webpack",
-		"web-watch": "webpack --watch",
+		"watch-web": "webpack --watch",
 		"lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
 		"test": "sh ./scripts/e2e.sh",


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- In the previous PR, the file paths were parsed to ``file:///`` scheme irrespective of whether the workspace is loaded from disk or from a remote repository. I have altered file handling in this PR so that the extension works even for workspaces pulled from a github (like ``cicero-template-library`` as given below)

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

https://user-images.githubusercontent.com/76606666/183601865-c0e09225-c887-43fa-b8d8-fddcc5623d75.mp4


### Related Issues
- Issue #101
- Pull Request #127

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`